### PR TITLE
Exit code is now passed along to bin/mandrel-runner stub

### DIFF
--- a/mandrel/runner.py
+++ b/mandrel/runner.py
@@ -86,11 +86,11 @@ class AbstractRunner(object):
 
     def run(self):
         target, args = self.process_options()
-        self.execute(target, args)
+        return self.execute(target, args)
 
     @classmethod
     def launch(cls):
-        cls().run()
+        return cls().run()
 
 
 class CallableRunner(AbstractRunner):
@@ -117,8 +117,7 @@ class ScriptRunner(AbstractRunner):
 
 
 def launch_callable():
-    CallableRunner.launch()
+    return CallableRunner.launch()
 
 def launch_script():
-    ScriptRunner.launch()
-
+    return ScriptRunner.launch()


### PR DESCRIPTION
- Without these return statements bin/mandrel-runner always returns None
- For completeness, I also added a return statement to the launch_script method
  *\* However, I haven't dived into the script code (just the runner)
  *\* It may actually not be needed
- All 84 tests seem to pass
